### PR TITLE
fix: prevent commit-evidence from running in main branch

### DIFF
--- a/.github/workflows/ci-sbom-sca.yml
+++ b/.github/workflows/ci-sbom-sca.yml
@@ -180,7 +180,9 @@ jobs:
 
   commit-evidence:
     needs: sbom_sca
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'
+    if: |
+      (github.event_name == 'workflow_dispatch' || github.event_name == 'push') &&
+      github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Контекст
hotfix


## Как проверял(а)
- [x] `ruff/black/isort` локально
- [x] `pytest -q` зелёный
- [x] `pre-commit run --all-files`
